### PR TITLE
Add current mowing zone tracking for Dreame A1 Pro

### DIFF
--- a/custom_components/dreame_mower/dreame/device.py
+++ b/custom_components/dreame_mower/dreame/device.py
@@ -890,12 +890,18 @@ class DreameMowerDevice:
                 self._ready = False
                 self.connect_device()
 
+            if self.status.docked:
+                self._reset_current_zone()
+
             if self._map_manager:
                 self._map_manager.editor.refresh_map()
 
     def _charging_status_changed(self, previous_charging_status: Any = None) -> None:
         self._remote_control = False
         if previous_charging_status is not None:
+            if self.status.docked:
+                self._reset_current_zone()
+
             if self._map_manager:
                 self._map_manager.editor.refresh_map()
 
@@ -1476,6 +1482,27 @@ class DreameMowerDevice:
 
             except Exception as ex:
                 _LOGGER.warning("Get Cleaning History failed!: %s", ex)
+
+    def _reset_current_zone(self) -> None:
+        """Clear current mowing zone when the mower is docked."""
+        if (
+            self.current_zone_id is None
+            and self.current_zone_state is None
+            and self.current_zone_raw is None
+        ):
+            return
+
+        _LOGGER.warning(
+            "DREAME_A1_CURRENT_ZONE_RESET previous_zone_id=%s previous_zone_state=%s previous_raw=%s",
+            self.current_zone_id,
+            self.current_zone_state,
+            self.current_zone_raw,
+        )
+        self.current_zone_id = None
+        self.current_zone_state = None
+        self.current_zone_raw = None
+        if self._ready:
+            self._property_changed()
 
     def _property_changed(self) -> None:
         """Call external listener when a property changed"""

--- a/custom_components/dreame_mower/dreame/device.py
+++ b/custom_components/dreame_mower/dreame/device.py
@@ -218,6 +218,9 @@ class DreameMowerDevice:
         self.host = host
         self.two_factor_url = None
         self.account_type = account_type
+        self.current_zone_id: int | None = None
+        self.current_zone_state: int | None = None
+        self.current_zone_raw: list | None = None
         self.status = DreameMowerDeviceStatus(self)
         self.capability = DreameMowerDeviceCapability(self)
 
@@ -389,6 +392,33 @@ class DreameMowerDevice:
                         param.get("did"),
                         param.get("value"),
                     )
+
+                    if (
+                        param.get("siid") == 2
+                        and param.get("piid") == 56
+                        and isinstance(param.get("value"), dict)
+                    ):
+                        zone_status = param["value"].get("status")
+                        if zone_status and isinstance(zone_status, list) and len(zone_status) > 0:
+                            current_zone_id = zone_status[0][0]
+                            current_zone_state = zone_status[0][1]
+                            zone_changed = (
+                                self.current_zone_id != current_zone_id
+                                or self.current_zone_state != current_zone_state
+                                or self.current_zone_raw != zone_status
+                            )
+                            self.current_zone_id = current_zone_id
+                            self.current_zone_state = current_zone_state
+                            self.current_zone_raw = zone_status
+                            _LOGGER.warning(
+                                "DREAME_A1_CURRENT_ZONE zone_id=%s zone_state=%s raw=%s",
+                                current_zone_id,
+                                current_zone_state,
+                                zone_status,
+                            )
+                            if zone_changed and self._ready:
+                                self._property_changed()
+
                     properties = [prop for prop in DreameMowerProperty]
                     for prop in properties:
                         if prop in self.property_mapping:

--- a/custom_components/dreame_mower/dreame/device.py
+++ b/custom_components/dreame_mower/dreame/device.py
@@ -381,7 +381,14 @@ class DreameMowerDevice:
                 params = []
                 map_params = []
                 for param in message["params"]:
-                    _LOGGER.warning("%s RAW: %s", DREAME_PROPERTY_LOG_PREFIX, param)
+                    _LOGGER.warning(
+                        "%s siid=%s piid=%s did=%s value=%s",
+                        DREAME_PROPERTY_LOG_PREFIX,
+                        param.get("siid"),
+                        param.get("piid"),
+                        param.get("did"),
+                        param.get("value"),
+                    )
                     properties = [prop for prop in DreameMowerProperty]
                     for prop in properties:
                         if prop in self.property_mapping:

--- a/custom_components/dreame_mower/dreame/device.py
+++ b/custom_components/dreame_mower/dreame/device.py
@@ -144,7 +144,12 @@ from .exceptions import (
 from .protocol import DreameMowerProtocol
 from .map import DreameMapMowerMapManager, DreameMowerMapDecoder
 
+
 _LOGGER = logging.getLogger(__name__)
+
+DREAME_RAW_EVENT_LOG_PREFIX = "DREAME_A1_RAW_EVENT"
+DREAME_PROPERTY_LOG_PREFIX = "DREAME_A1_PROPERTY"
+DREAME_MAP_PROPERTY_LOG_PREFIX = "DREAME_A1_MAP_PROPERTY"
 
 
 class DreameMowerDevice:
@@ -368,6 +373,7 @@ class DreameMowerDevice:
             return
 
         _LOGGER.debug("Message Callback: %s", message)
+        _LOGGER.warning("%s: %s", DREAME_RAW_EVENT_LOG_PREFIX, message)
 
         if "method" in message:
             self.available = True
@@ -375,6 +381,7 @@ class DreameMowerDevice:
                 params = []
                 map_params = []
                 for param in message["params"]:
+                    _LOGGER.warning("%s RAW: %s", DREAME_PROPERTY_LOG_PREFIX, param)
                     properties = [prop for prop in DreameMowerProperty]
                     for prop in properties:
                         if prop in self.property_mapping:
@@ -396,6 +403,12 @@ class DreameMowerDevice:
                                         or prop is DreameMowerProperty.ROBOT_TIME
                                         or prop is DreameMowerProperty.OLD_MAP_DATA
                                     ):
+                                        _LOGGER.warning(
+                                            "%s %s: %s",
+                                            DREAME_MAP_PROPERTY_LOG_PREFIX,
+                                            prop.name,
+                                            param,
+                                        )
                                         map_params.append(param)
                                 break
                 if len(map_params) and self._map_manager:

--- a/custom_components/dreame_mower/dreame/device.py
+++ b/custom_components/dreame_mower/dreame/device.py
@@ -742,6 +742,8 @@ class DreameMowerDevice:
                     self._map_manager.editor.refresh_map()
 
             if task_status is DreameMowerTaskStatus.COMPLETED:
+                self._reset_current_zone()
+
                 if (
                     previous_task_status is DreameMowerTaskStatus.CRUISING_PATH
                     or previous_task_status is DreameMowerTaskStatus.CRUISING_POINT
@@ -885,13 +887,14 @@ class DreameMowerDevice:
                 self._property_changed()
             elif status == DreameMowerStatus.CHARGING.value and previous_status == DreameMowerStatus.BACK_HOME.value:
                 self._cleaning_history_update = time.time()
+                self._reset_current_zone()
+
+            if status == DreameMowerStatus.CHARGING.value:
+                self._reset_current_zone()
 
             if previous_status == DreameMowerStatus.OTA.value:
                 self._ready = False
                 self.connect_device()
-
-            if self.status.docked:
-                self._reset_current_zone()
 
             if self._map_manager:
                 self._map_manager.editor.refresh_map()
@@ -899,8 +902,7 @@ class DreameMowerDevice:
     def _charging_status_changed(self, previous_charging_status: Any = None) -> None:
         self._remote_control = False
         if previous_charging_status is not None:
-            if self.status.docked:
-                self._reset_current_zone()
+            self._reset_current_zone()
 
             if self._map_manager:
                 self._map_manager.editor.refresh_map()

--- a/custom_components/dreame_mower/dreame/device.py
+++ b/custom_components/dreame_mower/dreame/device.py
@@ -376,7 +376,7 @@ class DreameMowerDevice:
             return
 
         _LOGGER.debug("Message Callback: %s", message)
-        _LOGGER.warning("%s: %s", DREAME_RAW_EVENT_LOG_PREFIX, message)
+        _LOGGER.debug("%s: %s", DREAME_RAW_EVENT_LOG_PREFIX, message)
 
         if "method" in message:
             self.available = True
@@ -384,7 +384,7 @@ class DreameMowerDevice:
                 params = []
                 map_params = []
                 for param in message["params"]:
-                    _LOGGER.warning(
+                    _LOGGER.debug(
                         "%s siid=%s piid=%s did=%s value=%s",
                         DREAME_PROPERTY_LOG_PREFIX,
                         param.get("siid"),
@@ -399,25 +399,64 @@ class DreameMowerDevice:
                         and isinstance(param.get("value"), dict)
                     ):
                         zone_status = param["value"].get("status")
-                        if zone_status and isinstance(zone_status, list) and len(zone_status) > 0:
-                            current_zone_id = zone_status[0][0]
-                            current_zone_state = zone_status[0][1]
-                            zone_changed = (
-                                self.current_zone_id != current_zone_id
-                                or self.current_zone_state != current_zone_state
-                                or self.current_zone_raw != zone_status
-                            )
-                            self.current_zone_id = current_zone_id
-                            self.current_zone_state = current_zone_state
-                            self.current_zone_raw = zone_status
-                            _LOGGER.warning(
-                                "DREAME_A1_CURRENT_ZONE zone_id=%s zone_state=%s raw=%s",
-                                current_zone_id,
-                                current_zone_state,
-                                zone_status,
-                            )
-                            if zone_changed and self._ready:
-                                self._property_changed()
+                        if zone_status and isinstance(zone_status, list):
+                            valid_zone_status = [
+                                zone
+                                for zone in zone_status
+                                if isinstance(zone, (list, tuple)) and len(zone) >= 2
+                            ]
+                            if not valid_zone_status:
+                                _LOGGER.debug(
+                                    "DREAME_A1_CURRENT_ZONE ignored malformed status payload: %s",
+                                    zone_status,
+                                )
+                            else:
+                                active_zone = None
+
+                                # Full-area mowing can report multiple zones. In that case the active zone
+                                # has been observed with state 0, while pending zones use state -1.
+                                if len(valid_zone_status) > 1:
+                                    for zone in valid_zone_status:
+                                        if zone[1] == 0:
+                                            active_zone = zone
+                                            break
+
+                                # Single-zone mowing has been observed with state 4 for the active zone.
+                                if active_zone is None:
+                                    for zone in valid_zone_status:
+                                        if zone[1] == 4:
+                                            active_zone = zone
+                                            break
+
+                                # Fallback: choose the first zone that is not pending.
+                                if active_zone is None:
+                                    for zone in valid_zone_status:
+                                        if zone[1] != -1:
+                                            active_zone = zone
+                                            break
+
+                                if active_zone is None:
+                                    active_zone = valid_zone_status[0]
+
+                                current_zone_id = active_zone[0]
+                                current_zone_state = active_zone[1]
+                                zone_changed = (
+                                    self.current_zone_id != current_zone_id
+                                    or self.current_zone_state != current_zone_state
+                                    or self.current_zone_raw != zone_status
+                                )
+                                self.current_zone_id = current_zone_id
+                                self.current_zone_state = current_zone_state
+                                self.current_zone_raw = zone_status
+                                _LOGGER.debug(
+                                    "DREAME_A1_CURRENT_ZONE zone_id=%s zone_state=%s raw=%s selected=%s",
+                                    current_zone_id,
+                                    current_zone_state,
+                                    zone_status,
+                                    active_zone,
+                                )
+                                if zone_changed and self._ready:
+                                    self._property_changed()
 
                     properties = [prop for prop in DreameMowerProperty]
                     for prop in properties:
@@ -440,7 +479,7 @@ class DreameMowerDevice:
                                         or prop is DreameMowerProperty.ROBOT_TIME
                                         or prop is DreameMowerProperty.OLD_MAP_DATA
                                     ):
-                                        _LOGGER.warning(
+                                        _LOGGER.debug(
                                             "%s %s: %s",
                                             DREAME_MAP_PROPERTY_LOG_PREFIX,
                                             prop.name,
@@ -889,7 +928,11 @@ class DreameMowerDevice:
                 self._cleaning_history_update = time.time()
                 self._reset_current_zone()
 
-            if status == DreameMowerStatus.CHARGING.value:
+            if (
+                status == DreameMowerStatus.BACK_HOME.value
+                or status == DreameMowerStatus.CHARGING.value
+                or self.status.docked
+            ):
                 self._reset_current_zone()
 
             if previous_status == DreameMowerStatus.OTA.value:
@@ -1494,7 +1537,7 @@ class DreameMowerDevice:
         ):
             return
 
-        _LOGGER.warning(
+        _LOGGER.debug(
             "DREAME_A1_CURRENT_ZONE_RESET previous_zone_id=%s previous_zone_state=%s previous_raw=%s",
             self.current_zone_id,
             self.current_zone_state,

--- a/custom_components/dreame_mower/sensor.py
+++ b/custom_components/dreame_mower/sensor.py
@@ -282,6 +282,26 @@ SENSORS: tuple[DreameMowerSensorEntityDescription, ...] = (
         entity_category=None,
     ),
     DreameMowerSensorEntityDescription(
+        key="current_zone_id",
+        name="Current Zone ID",
+        icon="mdi:map-marker-radius",
+        value_fn=lambda value, device: device.current_zone_id,
+        attrs_fn=lambda device: {
+            "zone_state": device.current_zone_state,
+            "raw": device.current_zone_raw,
+        },
+    ),
+    DreameMowerSensorEntityDescription(
+        key="current_zone_state",
+        name="Current Zone State",
+        icon="mdi:state-machine",
+        value_fn=lambda value, device: device.current_zone_state,
+        attrs_fn=lambda device: {
+            "zone_id": device.current_zone_id,
+            "raw": device.current_zone_raw,
+        },
+    ),
+    DreameMowerSensorEntityDescription(
         key="firmware_version",
         icon="mdi:chip",
         value_fn=lambda value, device: device.info.version,


### PR DESCRIPTION
This PR is fully backward compatible and does not modify existing mower behavior.

## Summary

This PR adds support for detecting and exposing the currently active mowing zone for Dreame A1 Pro devices.

The mower sends zone status updates through:

```python
siid=2, piid=56
```

with payloads like:

```python
{"status": [[zone_id, zone_state]]}
```

Example:

```python
{"status": [[1, 4]]}
```

where:
- `1` = active zone ID
- `4` = zone execution state reported by the mower

---

## What was added

### Current zone tracking

The integration now:
- parses zone status events from MQTT/device messages
- stores:
  - `current_zone_id`
  - `current_zone_state`
  - `current_zone_raw`
- updates Home Assistant entities immediately when the active zone changes

---

## Reset handling

The current zone is automatically reset when:
- task status becomes `COMPLETED`
- mower status changes to `CHARGING`
- charging status changes
- mower docks in the station

This prevents stale zone IDs from remaining after a completed mowing task.

The zone is automatically restored when a new mowing task starts.

---

## Logging / diagnostics

Additional debug logging was added to help reverse engineer Dreame A1 Pro realtime events:

- raw MQTT/device events
- property updates
- map-related properties
- current zone changes

Example logs:

```text
DREAME_A1_CURRENT_ZONE zone_id=2 zone_state=4 raw=[[2, 4]]
```

---

## Why this is useful

This enables:
- Home Assistant automations based on the active mowing zone
- realtime zone monitoring
- notifications per zone
- better dashboard visibility
- future support for zone progress tracking

---

## Tested on

- Dreame A1 Pro
- Home Assistant 2026.x
- Cloud + local MQTT mode

Tested scenarios:
- start zone mowing
- switch zones
- pause/resume
- return to dock
- docking reset
- restart after docking