### PR TITLE
feat: expose battery icon attribute

### DIFF
--- a/custom_components/dreame_mower/manifest.json
+++ b/custom_components/dreame_mower/manifest.json
@@ -18,5 +18,5 @@
     "py-mini-racer",
     "paho-mqtt"
   ],
-  "version": "1.8.3"
+  "version": "1.8.4"
 }

--- a/custom_components/dreame_mower/sensor.py
+++ b/custom_components/dreame_mower/sensor.py
@@ -17,6 +17,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.icon import icon_for_battery_level
 
 from .const import (
     DOMAIN,
@@ -116,6 +117,12 @@ SENSORS: tuple[DreameMowerSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.BATTERY,
         native_unit_of_measurement=UNIT_PERCENT,
         state_class=SensorStateClass.MEASUREMENT,
+        attrs_fn=lambda device: {
+            "icon": icon_for_battery_level(
+                battery_level=device.status.battery_level,
+                charging=device.status.charging,
+            ),
+        },
     ),
     DreameMowerSensorEntityDescription(
         property_key=DreameMowerProperty.BLADES_LEFT,


### PR DESCRIPTION
## Summary
- Exposes the dynamically computed battery icon as an `icon` attribute on the battery level sensor.
- Uses Home Assistant's `icon_for_battery_level(...)` with both battery level and charging state.

## Test Plan
- `python3 -m py_compile custom_components/dreame_mower/sensor.py`

Closes #10