### PR TITLE
fix: map A2 2000 low battery error code

### DIFF
--- a/custom_components/dreame_mower/coordinator.py
+++ b/custom_components/dreame_mower/coordinator.py
@@ -244,6 +244,14 @@ class DreameMowerDataUpdateCoordinator(DataUpdateCoordinator[DreameMowerDevice])
                         value = prop.get("value")
                         if value is not None and value > 0 and value in DreameMowerErrorCode._value2member_map_:
                             error_code = DreameMowerErrorCode(value)
+                            if (
+                                error_code is DreameMowerErrorCode.EDGE
+                                and self._device.info
+                                and self._device.info.model == "dreame.mower.g2568c"
+                                and self._device.status.battery_level is not None
+                                and self._device.status.battery_level <= 15
+                            ):
+                                error_code = DreameMowerErrorCode.BATTERY_LOW
                             lang = self.hass.config.language
                             desc = None
                             if lang == "fr":

--- a/custom_components/dreame_mower/dreame/device.py
+++ b/custom_components/dreame_mower/dreame/device.py
@@ -4823,19 +4823,40 @@ class DreameMowerDeviceStatus:
         faults = self._get_property(DreameMowerProperty.FAULTS)
         return 0 if faults == "" or faults == " " else faults
 
+    def _normalize_error_code(self, value: int | None) -> DreameMowerErrorCode | None:
+        """Return a model-aware normalized error code."""
+        if value is None or value not in DreameMowerErrorCode._value2member_map_:
+            return None
+
+        # A2 2000 (dreame.mower.g2568c) reports raw code 54 when the
+        # battery reaches 15% and the mower returns to charge. On A1 Pro,
+        # code 54 is still treated as an edge sensor error, so keep this
+        # override model-specific and gated by the low-battery threshold.
+        if (
+            value == DreameMowerErrorCode.EDGE.value
+            and self._device.info
+            and self._device.info.model == "dreame.mower.g2568c"
+            and self.battery_level is not None
+            and self.battery_level <= 15
+        ):
+            return DreameMowerErrorCode.BATTERY_LOW
+
+        return DreameMowerErrorCode(value)
+
     @property
     def error(self) -> DreameMowerErrorCode:
         """Return error of the device."""
         value = self._get_property(DreameMowerProperty.ERROR)
-        if value is not None and value in DreameMowerErrorCode._value2member_map_:
-            if value in (
-                DreameMowerErrorCode.LOW_BATTERY_TURN_OFF.value,
-                DreameMowerErrorCode.UNKNOWN_WARNING_2.value,
-                DreameMowerErrorCode.MOWING_COMPLETE.value,
-                DreameMowerErrorCode.TASK_CANCELLED.value,
+        error_code = self._normalize_error_code(value)
+        if error_code:
+            if error_code in (
+                DreameMowerErrorCode.LOW_BATTERY_TURN_OFF,
+                DreameMowerErrorCode.UNKNOWN_WARNING_2,
+                DreameMowerErrorCode.MOWING_COMPLETE,
+                DreameMowerErrorCode.TASK_CANCELLED,
             ):
                 return DreameMowerErrorCode.NO_ERROR
-            return DreameMowerErrorCode(value)
+            return error_code
         if value is not None:
             _LOGGER.debug("ERROR_CODE not supported: %s", value)
         return DreameMowerErrorCode.UNKNOWN


### PR DESCRIPTION
## Summary
- Adds a model-specific normalization for A2 2000 (`dreame.mower.g2568c`) where raw error code `54` at low battery is reported as `BATTERY_LOW` instead of the generic edge sensor error.
- Applies the same normalization when fetching detailed error descriptions from the coordinator.
- Keeps A1 Pro and other models unchanged, where code `54` can still mean edge sensor error.

Closes #14

## Validation
- `python3 -m compileall -q custom_components/dreame_mower`
- AST parse of changed Python files
