### PR TITLE
Improves the current zone tracking implementation

### DIFF
--- a/custom_components/dreame_mower/dreame/device.py
+++ b/custom_components/dreame_mower/dreame/device.py
@@ -890,12 +890,18 @@ class DreameMowerDevice:
                 self._ready = False
                 self.connect_device()
 
+            if self.status.docked:
+                self._reset_current_zone()
+
             if self._map_manager:
                 self._map_manager.editor.refresh_map()
 
     def _charging_status_changed(self, previous_charging_status: Any = None) -> None:
         self._remote_control = False
         if previous_charging_status is not None:
+            if self.status.docked:
+                self._reset_current_zone()
+
             if self._map_manager:
                 self._map_manager.editor.refresh_map()
 
@@ -1476,6 +1482,27 @@ class DreameMowerDevice:
 
             except Exception as ex:
                 _LOGGER.warning("Get Cleaning History failed!: %s", ex)
+
+    def _reset_current_zone(self) -> None:
+        """Clear current mowing zone when the mower is docked."""
+        if (
+            self.current_zone_id is None
+            and self.current_zone_state is None
+            and self.current_zone_raw is None
+        ):
+            return
+
+        _LOGGER.warning(
+            "DREAME_A1_CURRENT_ZONE_RESET previous_zone_id=%s previous_zone_state=%s previous_raw=%s",
+            self.current_zone_id,
+            self.current_zone_state,
+            self.current_zone_raw,
+        )
+        self.current_zone_id = None
+        self.current_zone_state = None
+        self.current_zone_raw = None
+        if self._ready:
+            self._property_changed()
 
     def _property_changed(self) -> None:
         """Call external listener when a property changed"""

--- a/custom_components/dreame_mower/dreame/device.py
+++ b/custom_components/dreame_mower/dreame/device.py
@@ -218,6 +218,9 @@ class DreameMowerDevice:
         self.host = host
         self.two_factor_url = None
         self.account_type = account_type
+        self.current_zone_id: int | None = None
+        self.current_zone_state: int | None = None
+        self.current_zone_raw: list | None = None
         self.status = DreameMowerDeviceStatus(self)
         self.capability = DreameMowerDeviceCapability(self)
 
@@ -389,6 +392,33 @@ class DreameMowerDevice:
                         param.get("did"),
                         param.get("value"),
                     )
+
+                    if (
+                        param.get("siid") == 2
+                        and param.get("piid") == 56
+                        and isinstance(param.get("value"), dict)
+                    ):
+                        zone_status = param["value"].get("status")
+                        if zone_status and isinstance(zone_status, list) and len(zone_status) > 0:
+                            current_zone_id = zone_status[0][0]
+                            current_zone_state = zone_status[0][1]
+                            zone_changed = (
+                                self.current_zone_id != current_zone_id
+                                or self.current_zone_state != current_zone_state
+                                or self.current_zone_raw != zone_status
+                            )
+                            self.current_zone_id = current_zone_id
+                            self.current_zone_state = current_zone_state
+                            self.current_zone_raw = zone_status
+                            _LOGGER.warning(
+                                "DREAME_A1_CURRENT_ZONE zone_id=%s zone_state=%s raw=%s",
+                                current_zone_id,
+                                current_zone_state,
+                                zone_status,
+                            )
+                            if zone_changed and self._ready:
+                                self._property_changed()
+
                     properties = [prop for prop in DreameMowerProperty]
                     for prop in properties:
                         if prop in self.property_mapping:

--- a/custom_components/dreame_mower/dreame/device.py
+++ b/custom_components/dreame_mower/dreame/device.py
@@ -381,7 +381,14 @@ class DreameMowerDevice:
                 params = []
                 map_params = []
                 for param in message["params"]:
-                    _LOGGER.warning("%s RAW: %s", DREAME_PROPERTY_LOG_PREFIX, param)
+                    _LOGGER.warning(
+                        "%s siid=%s piid=%s did=%s value=%s",
+                        DREAME_PROPERTY_LOG_PREFIX,
+                        param.get("siid"),
+                        param.get("piid"),
+                        param.get("did"),
+                        param.get("value"),
+                    )
                     properties = [prop for prop in DreameMowerProperty]
                     for prop in properties:
                         if prop in self.property_mapping:

--- a/custom_components/dreame_mower/dreame/device.py
+++ b/custom_components/dreame_mower/dreame/device.py
@@ -144,7 +144,12 @@ from .exceptions import (
 from .protocol import DreameMowerProtocol
 from .map import DreameMapMowerMapManager, DreameMowerMapDecoder
 
+
 _LOGGER = logging.getLogger(__name__)
+
+DREAME_RAW_EVENT_LOG_PREFIX = "DREAME_A1_RAW_EVENT"
+DREAME_PROPERTY_LOG_PREFIX = "DREAME_A1_PROPERTY"
+DREAME_MAP_PROPERTY_LOG_PREFIX = "DREAME_A1_MAP_PROPERTY"
 
 
 class DreameMowerDevice:
@@ -368,6 +373,7 @@ class DreameMowerDevice:
             return
 
         _LOGGER.debug("Message Callback: %s", message)
+        _LOGGER.warning("%s: %s", DREAME_RAW_EVENT_LOG_PREFIX, message)
 
         if "method" in message:
             self.available = True
@@ -375,6 +381,7 @@ class DreameMowerDevice:
                 params = []
                 map_params = []
                 for param in message["params"]:
+                    _LOGGER.warning("%s RAW: %s", DREAME_PROPERTY_LOG_PREFIX, param)
                     properties = [prop for prop in DreameMowerProperty]
                     for prop in properties:
                         if prop in self.property_mapping:
@@ -396,6 +403,12 @@ class DreameMowerDevice:
                                         or prop is DreameMowerProperty.ROBOT_TIME
                                         or prop is DreameMowerProperty.OLD_MAP_DATA
                                     ):
+                                        _LOGGER.warning(
+                                            "%s %s: %s",
+                                            DREAME_MAP_PROPERTY_LOG_PREFIX,
+                                            prop.name,
+                                            param,
+                                        )
                                         map_params.append(param)
                                 break
                 if len(map_params) and self._map_manager:

--- a/custom_components/dreame_mower/dreame/device.py
+++ b/custom_components/dreame_mower/dreame/device.py
@@ -742,6 +742,8 @@ class DreameMowerDevice:
                     self._map_manager.editor.refresh_map()
 
             if task_status is DreameMowerTaskStatus.COMPLETED:
+                self._reset_current_zone()
+
                 if (
                     previous_task_status is DreameMowerTaskStatus.CRUISING_PATH
                     or previous_task_status is DreameMowerTaskStatus.CRUISING_POINT
@@ -885,13 +887,14 @@ class DreameMowerDevice:
                 self._property_changed()
             elif status == DreameMowerStatus.CHARGING.value and previous_status == DreameMowerStatus.BACK_HOME.value:
                 self._cleaning_history_update = time.time()
+                self._reset_current_zone()
+
+            if status == DreameMowerStatus.CHARGING.value:
+                self._reset_current_zone()
 
             if previous_status == DreameMowerStatus.OTA.value:
                 self._ready = False
                 self.connect_device()
-
-            if self.status.docked:
-                self._reset_current_zone()
 
             if self._map_manager:
                 self._map_manager.editor.refresh_map()
@@ -899,8 +902,7 @@ class DreameMowerDevice:
     def _charging_status_changed(self, previous_charging_status: Any = None) -> None:
         self._remote_control = False
         if previous_charging_status is not None:
-            if self.status.docked:
-                self._reset_current_zone()
+            self._reset_current_zone()
 
             if self._map_manager:
                 self._map_manager.editor.refresh_map()

--- a/custom_components/dreame_mower/dreame/device.py
+++ b/custom_components/dreame_mower/dreame/device.py
@@ -436,6 +436,19 @@ class DreameMowerDevice:
                                     self._reset_current_zone()
                                     continue
 
+                                if (
+                                        self.status.docked
+                                        or self.status.status is DreameMowerStatus.CHARGING
+                                        or self.status.status is DreameMowerStatus.BACK_HOME
+                                ):
+                                    _LOGGER.debug(
+                                        "DREAME_A1_CURRENT_ZONE ignoring zone update while docked, charging or returning to base. raw=%s selected=%s",
+                                        zone_status,
+                                        active_zone,
+                                    )
+                                    self._reset_current_zone()
+                                    continue
+
                                 current_zone_id = active_zone[0]
                                 current_zone_state = active_zone[1]
                                 zone_changed = (

--- a/custom_components/dreame_mower/dreame/device.py
+++ b/custom_components/dreame_mower/dreame/device.py
@@ -376,7 +376,7 @@ class DreameMowerDevice:
             return
 
         _LOGGER.debug("Message Callback: %s", message)
-        _LOGGER.warning("%s: %s", DREAME_RAW_EVENT_LOG_PREFIX, message)
+        _LOGGER.debug("%s: %s", DREAME_RAW_EVENT_LOG_PREFIX, message)
 
         if "method" in message:
             self.available = True
@@ -384,7 +384,7 @@ class DreameMowerDevice:
                 params = []
                 map_params = []
                 for param in message["params"]:
-                    _LOGGER.warning(
+                    _LOGGER.debug(
                         "%s siid=%s piid=%s did=%s value=%s",
                         DREAME_PROPERTY_LOG_PREFIX,
                         param.get("siid"),
@@ -399,25 +399,64 @@ class DreameMowerDevice:
                         and isinstance(param.get("value"), dict)
                     ):
                         zone_status = param["value"].get("status")
-                        if zone_status and isinstance(zone_status, list) and len(zone_status) > 0:
-                            current_zone_id = zone_status[0][0]
-                            current_zone_state = zone_status[0][1]
-                            zone_changed = (
-                                self.current_zone_id != current_zone_id
-                                or self.current_zone_state != current_zone_state
-                                or self.current_zone_raw != zone_status
-                            )
-                            self.current_zone_id = current_zone_id
-                            self.current_zone_state = current_zone_state
-                            self.current_zone_raw = zone_status
-                            _LOGGER.warning(
-                                "DREAME_A1_CURRENT_ZONE zone_id=%s zone_state=%s raw=%s",
-                                current_zone_id,
-                                current_zone_state,
-                                zone_status,
-                            )
-                            if zone_changed and self._ready:
-                                self._property_changed()
+                        if zone_status and isinstance(zone_status, list):
+                            valid_zone_status = [
+                                zone
+                                for zone in zone_status
+                                if isinstance(zone, (list, tuple)) and len(zone) >= 2
+                            ]
+                            if not valid_zone_status:
+                                _LOGGER.debug(
+                                    "DREAME_A1_CURRENT_ZONE ignored malformed status payload: %s",
+                                    zone_status,
+                                )
+                            else:
+                                active_zone = None
+
+                                # Full-area mowing can report multiple zones. In that case the active zone
+                                # has been observed with state 0, while pending zones use state -1.
+                                if len(valid_zone_status) > 1:
+                                    for zone in valid_zone_status:
+                                        if zone[1] == 0:
+                                            active_zone = zone
+                                            break
+
+                                # Single-zone mowing has been observed with state 4 for the active zone.
+                                if active_zone is None:
+                                    for zone in valid_zone_status:
+                                        if zone[1] == 4:
+                                            active_zone = zone
+                                            break
+
+                                # Fallback: choose the first zone that is not pending.
+                                if active_zone is None:
+                                    for zone in valid_zone_status:
+                                        if zone[1] != -1:
+                                            active_zone = zone
+                                            break
+
+                                if active_zone is None:
+                                    active_zone = valid_zone_status[0]
+
+                                current_zone_id = active_zone[0]
+                                current_zone_state = active_zone[1]
+                                zone_changed = (
+                                    self.current_zone_id != current_zone_id
+                                    or self.current_zone_state != current_zone_state
+                                    or self.current_zone_raw != zone_status
+                                )
+                                self.current_zone_id = current_zone_id
+                                self.current_zone_state = current_zone_state
+                                self.current_zone_raw = zone_status
+                                _LOGGER.debug(
+                                    "DREAME_A1_CURRENT_ZONE zone_id=%s zone_state=%s raw=%s selected=%s",
+                                    current_zone_id,
+                                    current_zone_state,
+                                    zone_status,
+                                    active_zone,
+                                )
+                                if zone_changed and self._ready:
+                                    self._property_changed()
 
                     properties = [prop for prop in DreameMowerProperty]
                     for prop in properties:
@@ -440,7 +479,7 @@ class DreameMowerDevice:
                                         or prop is DreameMowerProperty.ROBOT_TIME
                                         or prop is DreameMowerProperty.OLD_MAP_DATA
                                     ):
-                                        _LOGGER.warning(
+                                        _LOGGER.debug(
                                             "%s %s: %s",
                                             DREAME_MAP_PROPERTY_LOG_PREFIX,
                                             prop.name,
@@ -889,7 +928,11 @@ class DreameMowerDevice:
                 self._cleaning_history_update = time.time()
                 self._reset_current_zone()
 
-            if status == DreameMowerStatus.CHARGING.value:
+            if (
+                status == DreameMowerStatus.BACK_HOME.value
+                or status == DreameMowerStatus.CHARGING.value
+                or self.status.docked
+            ):
                 self._reset_current_zone()
 
             if previous_status == DreameMowerStatus.OTA.value:
@@ -1494,7 +1537,7 @@ class DreameMowerDevice:
         ):
             return
 
-        _LOGGER.warning(
+        _LOGGER.debug(
             "DREAME_A1_CURRENT_ZONE_RESET previous_zone_id=%s previous_zone_state=%s previous_raw=%s",
             self.current_zone_id,
             self.current_zone_state,

--- a/custom_components/dreame_mower/dreame/device.py
+++ b/custom_components/dreame_mower/dreame/device.py
@@ -428,15 +428,13 @@ class DreameMowerDevice:
                                             active_zone = zone
                                             break
 
-                                # Fallback: choose the first zone that is not pending.
                                 if active_zone is None:
-                                    for zone in valid_zone_status:
-                                        if zone[1] != -1:
-                                            active_zone = zone
-                                            break
-
-                                if active_zone is None:
-                                    active_zone = valid_zone_status[0]
+                                    _LOGGER.debug(
+                                        "DREAME_A1_CURRENT_ZONE no active zone found, resetting current zone. raw=%s",
+                                        zone_status,
+                                    )
+                                    self._reset_current_zone()
+                                    continue
 
                                 current_zone_id = active_zone[0]
                                 current_zone_state = active_zone[1]
@@ -1529,7 +1527,7 @@ class DreameMowerDevice:
                 _LOGGER.warning("Get Cleaning History failed!: %s", ex)
 
     def _reset_current_zone(self) -> None:
-        """Clear current mowing zone when the mower is docked."""
+        """Clear current mowing zone when no zone is active."""
         if (
             self.current_zone_id is None
             and self.current_zone_state is None

--- a/custom_components/dreame_mower/dreame/device.py
+++ b/custom_components/dreame_mower/dreame/device.py
@@ -415,11 +415,10 @@ class DreameMowerDevice:
 
                                 # Full-area mowing can report multiple zones. In that case the active zone
                                 # has been observed with state 0, while pending zones use state -1.
-                                if len(valid_zone_status) > 1:
-                                    for zone in valid_zone_status:
-                                        if zone[1] == 0:
-                                            active_zone = zone
-                                            break
+                                for zone in valid_zone_status:
+                                    if zone[1] == 0:
+                                        active_zone = zone
+                                        break
 
                                 # Single-zone mowing has been observed with state 4 for the active zone.
                                 if active_zone is None:
@@ -956,7 +955,8 @@ class DreameMowerDevice:
     def _charging_status_changed(self, previous_charging_status: Any = None) -> None:
         self._remote_control = False
         if previous_charging_status is not None:
-            self._reset_current_zone()
+            if self.status.docked or self.status.charging:
+                self._reset_current_zone()
 
             if self._map_manager:
                 self._map_manager.editor.refresh_map()

--- a/custom_components/dreame_mower/dreame/device.py
+++ b/custom_components/dreame_mower/dreame/device.py
@@ -4584,9 +4584,9 @@ class DreameMowerDeviceStatus:
 
     def _get_property(self, prop: DreameMowerProperty) -> Any:
         """Helper function for accessing a property from device"""
-        _LOGGER.debug("Getting property: %s", prop)
+        # _LOGGER.debug("Getting property: %s", prop)
         result = self._device.get_property(prop)
-        _LOGGER.debug("Result: %s", result)
+        # _LOGGER.debug("Result: %s", result)
         return result
 
     @property

--- a/custom_components/dreame_mower/dreame/device.py
+++ b/custom_components/dreame_mower/dreame/device.py
@@ -436,9 +436,9 @@ class DreameMowerDevice:
                                     continue
 
                                 if (
-                                        self.status.docked
-                                        or self.status.status is DreameMowerStatus.CHARGING
-                                        or self.status.status is DreameMowerStatus.BACK_HOME
+                                    self.status.docked
+                                    or self.status.status == DreameMowerStatus.CHARGING.value
+                                    or self.status.status == DreameMowerStatus.BACK_HOME.value
                                 ):
                                     _LOGGER.debug(
                                         "DREAME_A1_CURRENT_ZONE ignoring zone update while docked, charging or returning to base. raw=%s selected=%s",

--- a/custom_components/dreame_mower/sensor.py
+++ b/custom_components/dreame_mower/sensor.py
@@ -282,6 +282,26 @@ SENSORS: tuple[DreameMowerSensorEntityDescription, ...] = (
         entity_category=None,
     ),
     DreameMowerSensorEntityDescription(
+        key="current_zone_id",
+        name="Current Zone ID",
+        icon="mdi:map-marker-radius",
+        value_fn=lambda value, device: device.current_zone_id,
+        attrs_fn=lambda device: {
+            "zone_state": device.current_zone_state,
+            "raw": device.current_zone_raw,
+        },
+    ),
+    DreameMowerSensorEntityDescription(
+        key="current_zone_state",
+        name="Current Zone State",
+        icon="mdi:state-machine",
+        value_fn=lambda value, device: device.current_zone_state,
+        attrs_fn=lambda device: {
+            "zone_id": device.current_zone_id,
+            "raw": device.current_zone_raw,
+        },
+    ),
+    DreameMowerSensorEntityDescription(
         key="firmware_version",
         icon="mdi:chip",
         value_fn=lambda value, device: device.info.version,


### PR DESCRIPTION
## Summary

This PR improves the current zone tracking implementation introduced in the previous PR.

During real-world testing on a Dreame A1 Pro, several edge cases were discovered related to multi-zone mowing, docking, charging, and task completion.

## Changes

### Improved active zone detection

Zone selection logic has been updated to correctly support:

`[[1, 0], [2, -1]] [[1, 2], [2, 0]] [[1, 2], [2, 2]] [[2, 0]] [[2, 4]] `

Observed behavior:

- 0 = active zone during multi-zone mowing
- 4 = active zone during single-zone mowing
- -1 = pending / not started
- 2 = completed

The integration now:

1. Selects the first zone with state 0
2. Falls back to the first zone with state 4
3. Resets the current zone if no active zone exists

This prevents completed zones from being incorrectly reported as active.

### Proper reset when no active zone exists

Previously, some payloads received after task completion could cause a completed zone to remain selected.

The integration now automatically clears:

`current_zone_id current_zone_state current_zone_raw `

when no active zone is present in the status payload.

### Ignore stale zone updates while docked or charging

Some A1 Pro devices continue sending zone status events after docking or while charging.

To prevent stale zone information from reappearing, zone updates are now ignored when the mower is:

- docked
- charging
- returning to base

### Additional payload validation

Added extra validation before processing zone status data.

Malformed payloads are safely ignored instead of being parsed.

### Merge compatibility fix

Fixed status comparisons after upstream synchronization by using enum values consistently when checking mower states.

## Why

These changes make current zone tracking significantly more reliable during:

- multi-zone mowing
- recharge and resume cycles
- task completion
- docking
- charging
- return-to-base operations

and prevent stale or incorrect zone information from being exposed to Home Assistant entities and automations.