### PR TITLE
fix: use native A1 Pro zone mowing API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Fix A1 Pro zone mowing by using the native mower task API instead of the
+  vacuum-derived `START_CUSTOM` segment payload.
+
 ## 1.8.8
 
 - Limit maintained hardware support to the Dreame A1 Pro

--- a/custom_components/dreame_mower/dreame/device.py
+++ b/custom_components/dreame_mower/dreame/device.py
@@ -3104,6 +3104,43 @@ class DreameMowerDevice:
         if not isinstance(selected_segments, list):
             selected_segments = [selected_segments]
 
+        # The A1 Pro uses the native mower task API for named map zones. The
+        # generic START_CUSTOM/"selects" payload is inherited from vacuums and
+        # is rejected by dreame.mower.g2422.
+        if self.info and self.info.model == "dreame.mower.g2422":
+            try:
+                zone_ids = [int(segment_id) for segment_id in selected_segments]
+            except (TypeError, ValueError):
+                raise InvalidActionException(
+                    f"Invalid A1 Pro zone ids: {selected_segments}"
+                ) from None
+
+            if not zone_ids or any(zone_id <= 0 for zone_id in zone_ids):
+                raise InvalidActionException(
+                    f"Invalid A1 Pro zone ids: {selected_segments}"
+                )
+
+            self.schedule_update(10, True)
+            result = self._protocol.action(
+                2,
+                50,
+                [{"m": "a", "p": 0, "o": 102, "d": {"region": zone_ids}}],
+            )
+            if not result or (
+                isinstance(result, dict)
+                and result.get("code") not in (None, 0)
+            ):
+                _LOGGER.error(
+                    "Send A1 Pro zone mowing failed for zones %s: %s",
+                    zone_ids,
+                    result,
+                )
+                self.schedule_update(1, True)
+                return None
+
+            _LOGGER.info("Send A1 Pro zone mowing for zones %s", zone_ids)
+            return result
+
         if cleaning_times is None or cleaning_times == "":
             cleaning_times = 1
 

--- a/tests/test_a1_pro_zone_mowing.py
+++ b/tests/test_a1_pro_zone_mowing.py
@@ -1,0 +1,94 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, call
+
+import pytest
+
+from dreame.device import DreameMowerDevice
+from dreame.exceptions import InvalidActionException
+from dreame.types import DreameMowerStatus
+
+
+def make_device(model: str = "dreame.mower.g2422") -> DreameMowerDevice:
+    device = object.__new__(DreameMowerDevice)
+    device.info = SimpleNamespace(model=model)
+    device.status = SimpleNamespace(
+        current_map=None,
+        has_saved_map=True,
+        current_segments={},
+        customized_cleaning=False,
+        started=True,
+        paused=False,
+    )
+    device._map_manager = None
+    device._update_status = Mock()
+    device._protocol = SimpleNamespace(action=Mock(return_value={"code": 0}))
+    device.schedule_update = Mock()
+    device.start_custom = Mock()
+    return device
+
+
+def test_a1_pro_zone_mowing_uses_native_mower_task_api():
+    device = make_device()
+
+    result = device.clean_segment(1)
+
+    assert result == {"code": 0}
+    device._protocol.action.assert_called_once_with(
+        2,
+        50,
+        [{"m": "a", "p": 0, "o": 102, "d": {"region": [1]}}],
+    )
+    device.start_custom.assert_not_called()
+    device.schedule_update.assert_called_once_with(10, True)
+
+
+def test_a1_pro_zone_mowing_rejects_non_positive_zone_ids():
+    device = make_device()
+
+    with pytest.raises(InvalidActionException, match="Invalid A1 Pro zone ids"):
+        device.clean_segment(0)
+
+    device._protocol.action.assert_not_called()
+
+
+def test_a1_pro_zone_mowing_rejects_non_numeric_zone_ids():
+    device = make_device()
+
+    with pytest.raises(InvalidActionException, match="Invalid A1 Pro zone ids"):
+        device.clean_segment("Jardin")
+
+    device._protocol.action.assert_not_called()
+
+
+def test_a1_pro_zone_mowing_schedules_fast_refresh_after_api_failure():
+    device = make_device()
+    device._protocol.action.return_value = None
+
+    result = device.clean_segment(1)
+
+    assert result is None
+    assert device.schedule_update.call_args_list == [call(10, True), call(1, True)]
+
+
+def test_a1_pro_zone_mowing_rejects_nonzero_api_code():
+    device = make_device()
+    device._protocol.action.return_value = {"code": 500}
+
+    result = device.clean_segment(1)
+
+    assert result is None
+    assert device.schedule_update.call_args_list == [call(10, True), call(1, True)]
+
+
+def test_other_models_keep_legacy_start_custom_segment_flow():
+    device = make_device("dreame.mower.other")
+    device.start_custom.return_value = {"code": 0}
+
+    result = device.clean_segment(2)
+
+    assert result == {"code": 0}
+    device._protocol.action.assert_not_called()
+    device.start_custom.assert_called_once_with(
+        DreameMowerStatus.SEGMENT_CLEANING.value,
+        '{"selects":[[2,1,1]]}',
+    )


### PR DESCRIPTION
## Summary

- route Dreame A1 Pro (`dreame.mower.g2422`) zone mowing through the native mower task API
- keep the existing `START_CUSTOM` segment flow for other models
- validate zone IDs and refresh quickly after a rejected API response
- add regression coverage for success, validation, API failures, and the legacy path

## Root cause

The inherited segment implementation sent a vacuum-style `START_CUSTOM` payload. The A1 Pro rejected that payload, while its native mower task API accepted the same zone IDs.

## Verification

- `6 passed` in `tests/test_a1_pro_zone_mowing.py`
- `py_compile` passed
- `git diff --check` passed
- live A1 Pro test: zone 1 started mowing and `sensor.a1_pro_current_zone_id` became `1`
