### PR TITLE
chore: release 1.8.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.8.9
 
 - Fix A1 Pro zone mowing by using the native mower task API instead of the
   vacuum-derived `START_CUSTOM` segment payload.

--- a/custom_components/dreame_mower/manifest.json
+++ b/custom_components/dreame_mower/manifest.json
@@ -18,5 +18,5 @@
     "py-mini-racer",
     "paho-mqtt"
   ],
-  "version": "1.8.8"
+  "version": "1.8.9"
 }


### PR DESCRIPTION
## Summary

- bump the integration manifest to `1.8.9`
- promote the A1 Pro native zone-mowing fix from Unreleased to `1.8.9`

## Verification

- 6 focused tests passed
- manifest JSON validation passed
- `git diff --check` passed
