### PR TITLE
fix: restore A1 Pro sensors after restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.8.10
+
+- Keep the A1 Pro state, charging status, and battery sensors registered when
+  the initial cloud property response is incomplete.
+- Restore the current mowing zone from Dreame cloud storage after Home
+  Assistant starts or reconnects during an active mowing task.
+
 ## 1.8.9
 
 - Fix A1 Pro zone mowing by using the native mower task API instead of the

--- a/custom_components/dreame_mower/dreame/device.py
+++ b/custom_components/dreame_mower/dreame/device.py
@@ -516,8 +516,27 @@ class DreameMowerDevice:
 
         return changed
 
+    def _request_current_zone(self) -> None:
+        """Hydrate the active A1 Pro mowing zone from Dreame cloud storage."""
+        try:
+            result = self._protocol.cloud.get_properties("2.56")
+        except Exception as ex:
+            _LOGGER.debug("Current zone cloud property request failed: %s", ex)
+            return
+
+        for param in result or []:
+            if not isinstance(param, dict) or param.get("key") != "2.56":
+                continue
+            value = param.get("value")
+            if isinstance(value, str):
+                try:
+                    value = json.loads(value)
+                except (TypeError, ValueError):
+                    continue
+            self._update_current_zone({"siid": 2, "piid": 56, "value": value})
+
     def _update_current_zone(self, param: dict[str, Any]) -> None:
-        """Update the active A1 Pro mowing zone from a cloud event."""
+        """Update the active A1 Pro mowing zone from a cloud event or property read."""
         if not isinstance(param, dict):
             return
         if param.get("siid") != 2 or param.get("piid") != 56:
@@ -1660,6 +1679,8 @@ class DreameMowerDevice:
             self._dirty_ai_data = {}
             try:
                 self._request_properties()
+                if self.status.started:
+                    self._request_current_zone()
             except Exception as ex:
                 _LOGGER.warning(
                     "Initial property request failed (MQTT will provide updates): %s", ex)
@@ -2430,6 +2451,8 @@ class DreameMowerDevice:
 
             if not self._protocol.dreame_cloud or force_request_properties:
                 self._request_properties(properties)
+                if force_request_properties and self.status.started:
+                    self._request_current_zone()
             elif self.status.map_backup_status:
                 self._request_properties([DreameMowerProperty.MAP_BACKUP_STATUS])
             elif self.status.map_recovery_status:

--- a/custom_components/dreame_mower/manifest.json
+++ b/custom_components/dreame_mower/manifest.json
@@ -18,5 +18,5 @@
     "py-mini-racer",
     "paho-mqtt"
   ],
-  "version": "1.8.9"
+  "version": "1.8.10"
 }

--- a/custom_components/dreame_mower/sensor.py
+++ b/custom_components/dreame_mower/sensor.py
@@ -73,6 +73,9 @@ SENSORS: tuple[DreameMowerSensorEntityDescription, ...] = (
     DreameMowerSensorEntityDescription(
         property_key=DreameMowerProperty.STATE,
         icon="mdi:robot-mower",
+        # The first cloud response can be partial. STATE is a core A1 Pro
+        # property and may arrive through MQTT only after platform setup.
+        exists_fn=lambda description, device: True,
     ),
     DreameMowerSensorEntityDescription(
         property_key=DreameMowerProperty.STATUS,
@@ -111,12 +114,16 @@ SENSORS: tuple[DreameMowerSensorEntityDescription, ...] = (
     DreameMowerSensorEntityDescription(
         property_key=DreameMowerProperty.CHARGING_STATUS,
         icon="mdi:home-lightning-bolt",
+        # Keep the entity registered when initial property discovery is partial.
+        exists_fn=lambda description, device: True,
     ),
     DreameMowerSensorEntityDescription(
         property_key=DreameMowerProperty.BATTERY_LEVEL,
         device_class=SensorDeviceClass.BATTERY,
         native_unit_of_measurement=UNIT_PERCENT,
         state_class=SensorStateClass.MEASUREMENT,
+        # Keep the entity registered when initial property discovery is partial.
+        exists_fn=lambda description, device: True,
         attrs_fn=lambda device: {
             "icon": icon_for_battery_level(
                 battery_level=device.status.battery_level,

--- a/tests/test_core_sensor_availability.py
+++ b/tests/test_core_sensor_availability.py
@@ -1,0 +1,39 @@
+import ast
+from pathlib import Path
+
+
+SENSOR_SOURCE = (
+    Path(__file__).parents[1]
+    / "custom_components"
+    / "dreame_mower"
+    / "sensor.py"
+)
+CORE_PROPERTIES = {"STATE", "CHARGING_STATUS", "BATTERY_LEVEL"}
+
+
+def test_core_sensors_are_registered_when_initial_discovery_is_partial():
+    tree = ast.parse(SENSOR_SOURCE.read_text())
+    unconditional = set()
+
+    for call in ast.walk(tree):
+        if not isinstance(call, ast.Call):
+            continue
+        if not isinstance(call.func, ast.Name):
+            continue
+        if call.func.id != "DreameMowerSensorEntityDescription":
+            continue
+
+        keywords = {keyword.arg: keyword.value for keyword in call.keywords}
+        property_key = keywords.get("property_key")
+        exists_fn = keywords.get("exists_fn")
+        if not (
+            isinstance(property_key, ast.Attribute)
+            and property_key.attr in CORE_PROPERTIES
+            and isinstance(exists_fn, ast.Lambda)
+            and isinstance(exists_fn.body, ast.Constant)
+            and exists_fn.body.value is True
+        ):
+            continue
+        unconditional.add(property_key.attr)
+
+    assert unconditional == CORE_PROPERTIES

--- a/tests/test_current_zone_restart.py
+++ b/tests/test_current_zone_restart.py
@@ -1,0 +1,65 @@
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from dreame.device import DreameMowerDevice
+
+
+DEVICE_SOURCE = (
+    Path(__file__).parents[1]
+    / "custom_components"
+    / "dreame_mower"
+    / "dreame"
+    / "device.py"
+)
+
+
+def _method_calls(method_name: str) -> list[str]:
+    tree = ast.parse(DEVICE_SOURCE.read_text())
+    method = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == method_name
+    )
+    return [
+        node.func.attr
+        for node in ast.walk(method)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+    ]
+
+
+def test_request_current_zone_hydrates_from_dreame_cloud_stored_property():
+    device = object.__new__(DreameMowerDevice)
+    device.current_zone_id = None
+    device.current_zone_state = None
+    device._ready = True
+    device._update_callback = Mock()
+    device._protocol = SimpleNamespace(
+        cloud=SimpleNamespace(
+            get_properties=Mock(
+                return_value=[
+                    {
+                        "key": "2.56",
+                        "value": '{"status":[[1,-1],[2,0],[3,-1]]}',
+                        "updateDate": 1786021219628,
+                    }
+                ]
+            )
+        )
+    )
+
+    device._request_current_zone()
+
+    device._protocol.cloud.get_properties.assert_called_once_with("2.56")
+    assert device.current_zone_id == 2
+    assert device.current_zone_state == 0
+    device._update_callback.assert_called_once_with()
+
+
+def test_connect_device_hydrates_current_zone_after_initial_properties():
+    assert "_request_current_zone" in _method_calls("connect_device")
+
+
+def test_forced_update_rehydrates_current_zone_after_reconnect():
+    assert "_request_current_zone" in _method_calls("update")


### PR DESCRIPTION
## Summary
- keep state, charging status, and battery entities registered when initial cloud discovery is partial
- hydrate the current mowing zone from Dreame cloud storage after startup or reconnect during an active task
- bump the integration to 1.8.10

## Validation
- 10 pytest tests passed
- Python compilation passed
- `git diff --check` passed
- verified on Home Assistant by restarting during an active A1 Pro mowing task: zone ID 1 and zone state 0 restored
- no mower action or property write added