### PR TITLE
feat: expose the active A1 Pro zone name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - Keep the A1 Pro state, charging status, and battery sensors registered when
   the initial cloud property response is incomplete.
 - Restore the current mowing zone from Dreame cloud storage after Home
-  Assistant starts or reconnects during an active mowing task.
+  Assistant starts or reconnects during an active mowing task, including the
+  zone name configured in the Dreame app/map.
 
 ## 1.8.9
 

--- a/custom_components/dreame_mower/dreame/device.py
+++ b/custom_components/dreame_mower/dreame/device.py
@@ -535,6 +535,15 @@ class DreameMowerDevice:
                     continue
             self._update_current_zone({"siid": 2, "piid": 56, "value": value})
 
+    @property
+    def current_zone_name(self) -> str | None:
+        """Return the app/map name of the active mowing zone."""
+        if self.current_zone_id is None:
+            return None
+        segments = self.status.current_segments or {}
+        segment = segments.get(self.current_zone_id)
+        return segment.name if segment else None
+
     def _update_current_zone(self, param: dict[str, Any]) -> None:
         """Update the active A1 Pro mowing zone from a cloud event or property read."""
         if not isinstance(param, dict):

--- a/custom_components/dreame_mower/sensor.py
+++ b/custom_components/dreame_mower/sensor.py
@@ -300,14 +300,30 @@ SENSORS: tuple[DreameMowerSensorEntityDescription, ...] = (
         name="Current Zone ID",
         icon="mdi:map-marker-radius",
         value_fn=lambda value, device: device.current_zone_id,
-        attrs_fn=lambda device: {"zone_state": device.current_zone_state},
+        attrs_fn=lambda device: {
+            "zone_name": device.current_zone_name,
+            "zone_state": device.current_zone_state,
+        },
+    ),
+    DreameMowerSensorEntityDescription(
+        key="current_zone_name",
+        name="Current Zone Name",
+        icon="mdi:map-marker",
+        value_fn=lambda value, device: device.current_zone_name,
+        attrs_fn=lambda device: {
+            "zone_id": device.current_zone_id,
+            "zone_state": device.current_zone_state,
+        },
     ),
     DreameMowerSensorEntityDescription(
         key="current_zone_state",
         name="Current Zone State",
         icon="mdi:state-machine",
         value_fn=lambda value, device: device.current_zone_state,
-        attrs_fn=lambda device: {"zone_id": device.current_zone_id},
+        attrs_fn=lambda device: {
+            "zone_id": device.current_zone_id,
+            "zone_name": device.current_zone_name,
+        },
     ),
     DreameMowerSensorEntityDescription(
         key="firmware_version",

--- a/tests/test_current_zone_restart.py
+++ b/tests/test_current_zone_restart.py
@@ -63,3 +63,13 @@ def test_connect_device_hydrates_current_zone_after_initial_properties():
 
 def test_forced_update_rehydrates_current_zone_after_reconnect():
     assert "_request_current_zone" in _method_calls("update")
+
+
+def test_current_zone_name_uses_the_name_loaded_from_the_dreame_map():
+    device = object.__new__(DreameMowerDevice)
+    device.current_zone_id = 2
+    device.status = SimpleNamespace(
+        current_segments={2: SimpleNamespace(name="Allée")}
+    )
+
+    assert device.current_zone_name == "Allée"


### PR DESCRIPTION
## Summary
- expose the current zone name already loaded from the Dreame app/map
- add `sensor.a1_pro_current_zone_name` and cross-link zone ID/name/state attributes
- preserve the numeric zone ID for dashboard automations

## Validation
- 11 tests passed
- Python compilation passed
- `git diff --check` passed
- runtime after HA restart: zone name `Jardin`, zone ID `1`, zone state `0`
- no mower action/write path added